### PR TITLE
"cross-fetch" fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-register": "^6.22.0",
     "coveralls": "^3.0.2",
     "cross-env": "^5.1.4",
+    "cross-fetch": "^2.2.2",
     "css-loader": "^0.26.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
@@ -68,7 +69,6 @@
   },
   "dependencies": {
     "body-parser": "^1.18.2",
-    "cross-fetch": "^2.2.2",
     "crypto-js": "^3.1.9-1",
     "ethers": "^3.0.15",
     "inchjs": "^0.4.1",


### PR DESCRIPTION
I faced an error using the library - `cross-fetch not found`
so I have to use hack: install cross-fetch to my main project and point it as `global.fetch = crossFetch`

this commit should fix an issue